### PR TITLE
Ms sql version provider

### DIFF
--- a/SimpleMigrations.sln
+++ b/SimpleMigrations.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleMigrations", "src\SimpleMigrations\SimpleMigrations.csproj", "{352D9BE8-3506-4F85-AD9A-7E5FB86BA5A8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleMigratorTests", "SimpleMigratorTests\SimpleMigratorTests.csproj", "{C3E6A43B-64C6-453E-AAAB-09EBA93D549C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{352D9BE8-3506-4F85-AD9A-7E5FB86BA5A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{352D9BE8-3506-4F85-AD9A-7E5FB86BA5A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{352D9BE8-3506-4F85-AD9A-7E5FB86BA5A8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3E6A43B-64C6-453E-AAAB-09EBA93D549C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3E6A43B-64C6-453E-AAAB-09EBA93D549C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3E6A43B-64C6-453E-AAAB-09EBA93D549C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3E6A43B-64C6-453E-AAAB-09EBA93D549C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SimpleMigratorTests/MsSqlVersionProviderTests.cs
+++ b/SimpleMigratorTests/MsSqlVersionProviderTests.cs
@@ -1,0 +1,29 @@
+﻿using System.Reflection;
+using NUnit.Framework;
+using SimpleMigrations;
+using SimpleMigrations.Console;
+using SimpleMigrations.VersionProvider;
+
+namespace SimpleMigratorTests
+{
+    [TestFixture]
+    public class MsSqlVersionProviderTests
+    {
+        [Test]
+        public static void Verify_MsSqlMigration()
+        {
+            const string connectionString = @"Server=.\SQLEXPRESS;Database=SimpleMigratorTests;Trusted_Connection=True;";
+            using (var connection = new System.Data.SqlClient.SqlConnection(connectionString) )
+            {
+                connection.Open();
+                var migrationsAssembly = typeof(MsSqlVersionProviderTests).Assembly;
+                var versionProvider = new MsSqlVersionProvider();
+                var migrator = new SimpleMigrator(migrationsAssembly, connection, versionProvider);
+                migrator.Load();
+
+                migrator.MigrateToLatest();
+
+            }
+        }
+    }
+}

--- a/SimpleMigratorTests/Properties/AssemblyInfo.cs
+++ b/SimpleMigratorTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SimpleMigratorTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SimpleMigratorTests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c3e6a43b-64c6-453e-aaab-09eba93d549c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SimpleMigratorTests/SimpleMigratorTests.csproj
+++ b/SimpleMigratorTests/SimpleMigratorTests.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C3E6A43B-64C6-453E-AAAB-09EBA93D549C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SimpleMigratorTests</RootNamespace>
+    <AssemblyName>SimpleMigratorTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MsSqlVersionProviderTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestMigrations\AddUser.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\SimpleMigrations\SimpleMigrations.csproj">
+      <Project>{352D9BE8-3506-4F85-AD9A-7E5FB86BA5A8}</Project>
+      <Name>SimpleMigrations</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/SimpleMigratorTests/TestMigrations/AddUser.cs
+++ b/SimpleMigratorTests/TestMigrations/AddUser.cs
@@ -1,0 +1,20 @@
+﻿using SimpleMigrations;
+
+namespace SimpleMigratorTests.TestMigrations
+{
+    [Migration(1, useTransaction:false)]
+    public class AddUser : Migration
+    {
+        public override void Up()
+        {
+            Execute(@"CREATE TABLE Users (
+                [Id] [int] IDENTITY(1,1)  PRIMARY KEY NOT NULL,
+                Name TEXT NOT NULL);");
+        }
+
+        public override void Down()
+        {
+            Execute("DROP TABLE Users");
+        }
+    }
+}

--- a/SimpleMigratorTests/packages.config
+++ b/SimpleMigratorTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.5.0" targetFramework="net452" />
+</packages>

--- a/src/SimpleMigrations/ConnectionProvider.cs
+++ b/src/SimpleMigrations/ConnectionProvider.cs
@@ -6,7 +6,7 @@ namespace SimpleMigrations
     /// <summary>
     /// Implements <see cref="IConnectionProvider{TDatabase}"/> for <see cref="IDbConnection"/> connections
     /// </summary>
-    public class ConnectionProvider : IConnectionProvider<IDbConnection>
+    public class ConnectionProvider : IConnectionProvider<IDbConnection, IDbTransaction>
     {
         private readonly IDbConnection connection;
         private IDbTransaction transaction;
@@ -19,6 +19,10 @@ namespace SimpleMigrations
             get { return this.connection; }
         }
 
+        public IDbTransaction Transaction
+        {
+            get { return this.transaction; }
+        }
         /// <summary>
         /// Instantiates a new instance of the <see cref="ConnectionProvider"/> class
         /// </summary>

--- a/src/SimpleMigrations/IConnectionProvider.cs
+++ b/src/SimpleMigrations/IConnectionProvider.cs
@@ -1,16 +1,22 @@
-﻿namespace SimpleMigrations
+﻿using System.Data;
+
+namespace SimpleMigrations
 {
     /// <summary>
     /// Provider which gives access to a database connection. Used to provide the connection to migrations, and to perform transactions
     /// </summary>
     /// <typeparam name="TDatabase">Type of the database being provided</typeparam>
-    public interface IConnectionProvider<TDatabase>
+    /// <typeparam name="TTransaction">Type of the transaction being provided</typeparam>
+    public interface IConnectionProvider<out TDatabase, out TTransaction>
     {
         /// <summary>
         /// Gets the connection, which will be given to migrations
         /// </summary>
         TDatabase Connection { get; }
-
+        /// <summary>
+        /// Gets the transaction, which will be given to migrations
+        /// </summary>
+        TTransaction Transaction { get; }
         /// <summary>
         /// Begins a transaction
         /// </summary>

--- a/src/SimpleMigrations/IMigration.cs
+++ b/src/SimpleMigrations/IMigration.cs
@@ -4,12 +4,14 @@
     /// Interface which must be implemented by all migrations, although you probably want to derive from <see cref="Migration"/> instead
     /// </summary>
     /// <typeparam name="TDatabase">Type of database connection which this migration will use</typeparam>
-    public interface IMigration<TDatabase>
+    public interface IMigration<TDatabase, TTransaction>
     {
         /// <summary>
         /// Gets or sets the database to be used by this migration
         /// </summary>
         TDatabase DB { get; set; }
+
+        TTransaction Transaction { get; set; }
 
         /// <summary>
         /// Gets or sets the logger to be used by this migration

--- a/src/SimpleMigrations/IVersionProvider.cs
+++ b/src/SimpleMigrations/IVersionProvider.cs
@@ -4,7 +4,7 @@
     /// Interface representing the ability to interact with the Version table in the database
     /// </summary>
     /// <typeparam name="TDatabase">Type of database connection</typeparam>
-    public interface IVersionProvider<TDatabase>
+    public interface IVersionProvider<in TDatabase, in TTransaction>
     {
         /// <summary>
         /// Ensure that the version table exists, creating it if necessary
@@ -26,6 +26,8 @@
         /// <param name="oldVersion">Version being upgraded from</param>
         /// <param name="newVersion">Version being upgraded to</param>
         /// <param name="newDescription">Description to associate with the new version</param>
-        void UpdateVersion(TDatabase connection, long oldVersion, long newVersion, string newDescription);
+        /// <param name="transaction">Transaction to use to perform this action</param>
+        void UpdateVersion(TDatabase connection, TTransaction transaction, long oldVersion, long newVersion, string newDescription);
+        
     }
 }

--- a/src/SimpleMigrations/Migration.cs
+++ b/src/SimpleMigrations/Migration.cs
@@ -6,12 +6,14 @@ namespace SimpleMigrations
     /// Base class, intended to be used by all migrations (although you may implement <see cref="IMigration{TDatabase}"/> directly if you wish).
     /// Migrations MUST apply the <see cref="MigrationAttribute"/> attribute
     /// </summary>
-    public abstract class Migration : IMigration<IDbConnection>
+    public abstract class Migration : IMigration<IDbConnection, IDbTransaction>
     {
         /// <summary>
         /// Gets or sets the database to be used by this migration
         /// </summary>
         public IDbConnection DB { get; set; }
+
+        public IDbTransaction Transaction { get; set; }
 
         /// <summary>
         /// Gets or sets the logger to be used by this migration
@@ -38,6 +40,7 @@ namespace SimpleMigrations
 
             using (var command = this.DB.CreateCommand())
             {
+                command.Transaction = Transaction;
                 command.CommandText = sql;
                 command.ExecuteNonQuery();
             }

--- a/src/SimpleMigrations/SimpleMigrations.csproj
+++ b/src/SimpleMigrations/SimpleMigrations.csproj
@@ -56,6 +56,7 @@
     <Compile Include="MigrationException.cs" />
     <Compile Include="NullLogger.cs" />
     <Compile Include="VersionProvider\PostgresqlVersionProvider.cs" />
+    <Compile Include="VersionProvider\MsSqlVersionProvider.cs" />
     <Compile Include="VersionProvider\SqliteVersionProvider.cs" />
     <Compile Include="VersionProviderBase.cs" />
     <Compile Include="IConnectionProvider.cs" />

--- a/src/SimpleMigrations/SimpleMigrator.cs
+++ b/src/SimpleMigrations/SimpleMigrator.cs
@@ -6,7 +6,7 @@ namespace SimpleMigrations
     /// <summary>
     /// Migrator which uses <see cref="IDbConnection"/> connections
     /// </summary>
-    public class SimpleMigrator : SimpleMigrator<IDbConnection, IMigration<IDbConnection>>
+    public class SimpleMigrator : SimpleMigrator<IDbConnection, IDbTransaction, IMigration<IDbConnection, IDbTransaction>>
     {
         /// <summary>
         /// Instantiates a new instance of the <see cref="SimpleMigrator"/> class
@@ -18,7 +18,7 @@ namespace SimpleMigrations
         public SimpleMigrator(
             Assembly migrationAssembly,
             IDbConnection connection,
-            IVersionProvider<IDbConnection> versionProvider,
+            IVersionProvider<IDbConnection, IDbTransaction> versionProvider,
             ILogger logger = null)
             : base(migrationAssembly, new ConnectionProvider(connection), versionProvider, logger)
         {

--- a/src/SimpleMigrations/VersionProvider/MsSqlVersionProvider.cs
+++ b/src/SimpleMigrations/VersionProvider/MsSqlVersionProvider.cs
@@ -1,0 +1,59 @@
+﻿using System;
+
+namespace SimpleMigrations.VersionProvider
+{
+    /// <summary>
+    /// Class which can read from / write to a version table in an SQLite database
+    /// </summary>
+    public class MsSqlVersionProvider : VersionProviderBase
+    {
+        /// <summary>
+        /// Gets or sets the name of the table to use. Defaults to 'VersionInfo'
+        /// </summary>
+        public string TableName { get; set; }
+
+        /// <summary>
+        /// Instantiates a new instance of the <see cref="SQLiteVersionProvider"/> class
+        /// </summary>
+        public MsSqlVersionProvider()
+        {
+            this.TableName = "Version";
+        }
+
+        /// <summary>
+        /// Returns SQL to create the version table
+        /// </summary>
+        /// <returns>SQL to create the version table</returns>
+        public override string GetCreateVersionTableSql()
+        {
+            return string.Format(
+                @"IF  NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID('[dbo].[{0}]') AND type in (N'U'))
+                BEGIN
+                CREATE TABLE [dbo].[{0}](
+	                [Id] [int] IDENTITY(1,1)  PRIMARY KEY NOT NULL,
+	                [Version] [int] NOT NULL,
+	                [AppliedOn] [datetime] NOT NULL,
+	                [Description] [nvarchar](128) NOT NULL,
+                )
+                END;", TableName);
+        }
+
+        /// <summary>
+        /// Returns SQL to fetch the current version from the version table
+        /// </summary>
+        /// <returns>SQL to fetch the current version from the version table</returns>
+        public override string GetCurrentVersionSql()
+        {
+            return string.Format(@"SELECT TOP 1 [Version] FROM [dbo].[{0}] ORDER BY [Id] desc;", TableName);
+        }
+
+        /// <summary>
+        /// Returns SQL to update the current version in the version table
+        /// </summary>
+        /// <returns>SQL to update the current version in the version table</returns>
+        public override string GetSetVersionSql()
+        {
+            return string.Format(@"INSERT INTO [dbo].[{0}] ([Version], [AppliedOn], [Description]) VALUES (@Version, GETDATE(), @Description);", TableName);
+        }
+    }
+}

--- a/src/SimpleMigrations/VersionProviderBase.cs
+++ b/src/SimpleMigrations/VersionProviderBase.cs
@@ -6,7 +6,7 @@ namespace SimpleMigrations
     /// <summary>
     /// Version provider which acts by maintaining a table of applied versions
     /// </summary>
-    public abstract class VersionProviderBase : IVersionProvider<IDbConnection>
+    public abstract class VersionProviderBase : IVersionProvider<IDbConnection, IDbTransaction>
     {
         /// <summary>
         /// Ensure that the version table exists, creating it if necessary
@@ -57,12 +57,12 @@ namespace SimpleMigrations
         /// <param name="oldVersion">Version being upgraded from</param>
         /// <param name="newVersion">Version being upgraded to</param>
         /// <param name="newDescription">Description to associate with the new version</param>
-        public void UpdateVersion(IDbConnection connection, long oldVersion, long newVersion, string newDescription)
+        public void UpdateVersion(IDbConnection connection, IDbTransaction transaction, long oldVersion, long newVersion, string newDescription)
         {
             using (var cmd = connection.CreateCommand())
             {
                 cmd.CommandText = this.GetSetVersionSql();
-
+                cmd.Transaction = transaction;
                 var versionParam = cmd.CreateParameter();
                 versionParam.ParameterName = "Version";
                 versionParam.Value = newVersion;


### PR DESCRIPTION
Hi
I have added a MsSqlVersionProvider and a test project.
Please note. The "Transactions" must be false. Otherwise you need to extend the ConnectionProvider with IConnectionProvider<IDbConnection,IDBTransaction> (i.e. add <TTransaction>). And return the transaction on the begintransaction in SimpleMigrator (And where ever else the generic is needed)

You see the command for the MsSql needs the transaction.. Up to you. Other DBs may have the same issue?

I can add it for you if you like?

By the way. Great little migrator. Saved me lots of trouble and bother. Didn't have to do FluentMigrator, nor Enity. Nice and thin.. Thanks.

I can add the MySql also if you like?
